### PR TITLE
Implementa possibilidade de valor padrão para campos bool

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,33 @@
+
+name: Pull Request
+
+on:
+  pull_request:
+
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  unittests:
+    name: Terraform v${{matrix.terraform_version}}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform_version: ['1.6.6', '1.7.2']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{matrix.terraform_version}}
+
+      - name: Terraform init (v${{matrix.terraform_version}})
+        run: |
+          terraform init
+
+      - name: Run Tests
+        run: |
+          terraform test

--- a/README.md
+++ b/README.md
@@ -33,3 +33,21 @@ module "tf-gapi" {
 #### Exemplos
 
 Os exemplos podem ser encontrados na [pasta de exemplos](examples/)
+
+# Guia de desenvolvimentos
+
+O projeto é desenvolvido usando o [framework de teste](https://developer.hashicorp.com/terraform/language/tests) do próprio terraform.
+
+## Rodando os testes
+
+Para rodar os testes você precisará usar o terrform 1.6+. Primeiro precisa inicializar o proejto terraform, com:
+
+```
+terraform init
+```
+
+Os testes estão em `test/` e podem ser rodados com:
+
+```
+terraform test
+```

--- a/customResourceDefinitions.tf
+++ b/customResourceDefinitions.tf
@@ -3,6 +3,11 @@ locals {
     for manifest in module.manifests[*].manifest : manifest
     if manifest.apiVersion == "tf-gapi.lukerops.com/v1alpha1" && manifest.kind == "CustomResourceDefinition"
   ]
+
+  v1alpha2_manifests = [
+    for manifest in module.manifests[*].manifest : manifest
+    if manifest.apiVersion == "tf-gapi.lukerops.com/v1alpha2" && manifest.kind == "CustomResourceDefinition"
+  ]
 }
 
 module "custom_resource_definitions_v1alpha1" {
@@ -10,4 +15,11 @@ module "custom_resource_definitions_v1alpha1" {
   count  = length(local.v1alpha1_manifests)
 
   manifest = local.v1alpha1_manifests[count.index]
+}
+
+module "custom_resource_definitions_v1alpha2" {
+  source = "./modules/CustomResourceDefinition/v1alpha2/"
+  count  = length(local.v1alpha2_manifests)
+
+  manifest = local.v1alpha2_manifests[count.index]
 }

--- a/modules/CustomResourceDefinition/v1alpha2/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/outputs.tf
@@ -1,0 +1,126 @@
+locals {
+  error_messages = {
+    field_not_found              = <<-EOT
+      Invalid "spec" for CustomResourceDefinition!
+      The property "spec.%s" are required.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    invalid_metadata_name        = <<-EOT
+      Invalid "name" for CustomResourceDefinition!
+      The "metadata.name" must be in the format "<lower case kind>.<group>".
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    kind_not_camel_cased         = <<-EOT
+      Invalid "spec.kind" for CustomResourceDefinition!
+      The "spec.kind" must be CamelCased.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    versions_field_is_not_a_list = <<-EOT
+      Invalid "spec.versions" for CustomResourceDefinition!
+      The "spec.versions" must be a list.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    invalid_versions_size        = <<-EOT
+      Invalid "spec.versions" for CustomResourceDefinition!
+      The "spec.versions" must have at least 1 element.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+  }
+
+  kind_first_letter = try(substr(var.manifest.spec.kind, 0, 1), "")
+}
+
+module "version" {
+  source = "./version/"
+  count  = try(length(var.manifest.spec.versions), 0)
+
+  path           = var.manifest.path
+  name           = try(var.manifest.metadata.name, null)
+  index          = count.index
+  schema_version = var.manifest.spec.versions[count.index]
+}
+
+output "schemas" {
+  value = [
+    for version in module.version[*].schema_version : {
+      path       = var.manifest.path
+      apiVersion = try("${var.manifest.spec.group}/${version.name}", null)
+      kind       = try(var.manifest.spec.kind, null)
+      enabled    = version.enabled
+      deprecated = version.deprecated
+      specSchema = version.specSchema
+    }
+  ]
+
+  precondition {
+    condition = can(var.manifest.spec.group)
+    error_message = format(
+      local.error_messages.field_not_found,
+      "group",
+      var.manifest.metadata.name,
+      var.manifest.path,
+    )
+  }
+
+  precondition {
+    condition = can(var.manifest.spec.kind)
+    error_message = format(
+      local.error_messages.field_not_found,
+      "kind",
+      var.manifest.metadata.name,
+      var.manifest.path,
+    )
+  }
+
+  precondition {
+    condition = can(var.manifest.spec.versions)
+    error_message = format(
+      local.error_messages.field_not_found,
+      "versions",
+      var.manifest.metadata.name,
+      var.manifest.path,
+    )
+  }
+
+  precondition {
+    condition = try(
+      var.manifest.metadata.name == "${lower(var.manifest.spec.kind)}.${var.manifest.spec.group}",
+      true,
+    )
+    error_message = format(
+      local.error_messages.invalid_metadata_name,
+      var.manifest.metadata.name,
+      var.manifest.path,
+    )
+  }
+
+  precondition {
+    condition = local.kind_first_letter == upper(local.kind_first_letter)
+    error_message = format(
+      local.error_messages.kind_not_camel_cased,
+      var.manifest.metadata.name,
+      var.manifest.path,
+    )
+  }
+
+  precondition {
+    condition = can(tolist(var.manifest.spec.versions))
+    error_message = format(
+      local.error_messages.versions_field_is_not_a_list,
+      var.manifest.metadata.name,
+      var.manifest.path,
+    )
+  }
+
+  precondition {
+    condition = try(
+      length(var.manifest.spec.versions) > 0,
+      true,
+    )
+    error_message = format(
+      local.error_messages.invalid_versions_size,
+      var.manifest.metadata.name,
+      var.manifest.path,
+    )
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/variables.tf
@@ -1,0 +1,11 @@
+variable "manifest" {
+  type = object({
+    path       = string
+    apiVersion = string
+    kind       = string
+    metadata = object({
+      name = string
+    })
+    spec = any
+  })
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/outputs.tf
@@ -1,0 +1,127 @@
+locals {
+  error_messages = {
+    field_not_found                        = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The property "spec.versions[%d].%s" are required.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    wrong_specSchema_root_type             = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The type for "spec.versions[%d].specSchema.type" must be "object" (got "%s").
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    wrong_specSchema_properties_field_type = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The field "spec.versions[%d].specSchema.properties" must be an object.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    empty_specSchema_properties            = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The field "spec.versions[%d].specSchema.properties" must have at least one element.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+  }
+
+  version_enabled    = try(var.schema_version.enabled, true)
+  version_deprecated = try(var.schema_version.deprecated, false)
+  specSchema_type    = try(var.schema_version.specSchema.type, "object")
+
+  properties      = try(var.schema_version.specSchema.properties, {})
+  properties_size = try(length(keys(var.schema_version.specSchema.properties)), 1)
+}
+
+module "property" {
+  source   = "./property/"
+  for_each = toset(try(keys(local.properties), []))
+
+  path     = var.path
+  name     = var.name
+  property = "spec.versions[${var.index}].specSchema.properties.${each.key}"
+  options  = local.properties[each.key]
+}
+
+output "schema_version" {
+  value = {
+    name       = try(var.schema_version.name, null)
+    enabled    = local.version_enabled
+    deprecated = local.version_deprecated
+    specSchema = {
+      for property, result in module.property : property => result.options
+    }
+  }
+
+  precondition {
+    condition = can(var.schema_version.name)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.index,
+      "name",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = can(var.schema_version.specSchema)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.index,
+      "specSchema",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = can(var.schema_version.specSchema.type)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.index,
+      "specSchema.type",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = local.specSchema_type == "object"
+    error_message = format(
+      local.error_messages.wrong_specSchema_root_type,
+      var.index,
+      local.specSchema_type,
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = can(var.schema_version.specSchema.properties)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.index,
+      "specSchema.properties",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = can(keys(local.properties))
+    error_message = format(
+      local.error_messages.wrong_specSchema_properties_field_type,
+      var.index,
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = local.properties_size > 0
+    error_message = format(
+      local.error_messages.empty_specSchema_properties,
+      var.index,
+      var.name,
+      var.path,
+    )
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/array/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/array/outputs.tf
@@ -1,0 +1,111 @@
+locals {
+  error_messages = {
+    field_not_found       = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The property "%s.%s" are required.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    invalid_property_type = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The type for the property "%s.items.type" must be one of %#v (got "%s").
+      (metadata.name: "%s"; path: "%s")
+    EOT
+  }
+
+  valid_types = ["string", "integer", "object", "bool"]
+  type        = try(var.options.items.type, "empty")
+
+  common_options = {
+    description  = try(var.options.description, null)
+    externalDocs = try(var.options.externalDocs, null)
+  }
+  options = flatten([
+    module.string[*].options,
+    module.integer[*].options,
+    module.bool[*].options,
+    module.object[*].options,
+  ])
+}
+
+module "string" {
+  source = "../string/"
+  count  = local.type == "string" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = "${var.property}.items"
+  options  = try(var.options.items, {})
+}
+
+module "integer" {
+  source = "../integer/"
+  count  = local.type == "integer" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = "${var.property}.items"
+  options  = try(var.options.items, {})
+}
+
+module "bool" {
+  source = "../bool/"
+  count  = local.type == "bool" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = "${var.property}.items"
+  options  = try(var.options.items, {})
+}
+
+module "object" {
+  source = "../object/"
+  count  = local.type == "object" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = "${var.property}.items"
+  options  = try(var.options.items, {})
+}
+
+output "options" {
+  value = {
+    type     = "array"
+    minItems = try(tonumber(var.options.minItems), null)
+    maxItems = try(tonumber(var.options.maxItems), null)
+    items    = merge(local.common_options, local.options...)
+  }
+
+  precondition {
+    condition = can(var.options.items)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.property,
+      "items",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = can(var.options.items.type)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.property,
+      "items.type",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = try(contains(local.valid_types, var.options.items.type), true)
+    error_message = format(
+      local.error_messages.invalid_property_type,
+      var.property,
+      local.valid_types,
+      local.type,
+      var.name,
+      var.path,
+    )
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/array/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/array/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "property" {
+  type = string
+}
+
+variable "options" {
+  type = any
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/bool/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/bool/outputs.tf
@@ -1,0 +1,6 @@
+output "options" {
+  value = {
+    type    = "bool"
+    default = try(var.options.default, null)
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/bool/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/bool/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "property" {
+  type = string
+}
+
+variable "options" {
+  type = any
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/integer/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/integer/outputs.tf
@@ -1,0 +1,7 @@
+output "options" {
+  value = {
+    type    = "integer"
+    minimum = try(tonumber(var.options.minimum), null)
+    maximum = try(tonumber(var.options.maximum), null)
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/integer/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/integer/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "property" {
+  type = string
+}
+
+variable "options" {
+  type = any
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/object/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/object/outputs.tf
@@ -1,0 +1,72 @@
+locals {
+  error_messages = {
+    field_not_found             = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The property "%s.%s" are required.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    wrong_properties_field_type = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The field "%s.properties" must be an object.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    empty_properties            = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The field "%s.properties" must have at least one element.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+  }
+
+  properties      = try(var.options.properties, {})
+  properties_size = try(length(keys(var.options.properties)), 1)
+}
+
+module "property" {
+  source   = "./property/"
+  for_each = toset(try(keys(local.properties), []))
+
+  path     = var.path
+  name     = var.name
+  property = "${var.property}.properties.${each.key}"
+  options  = local.properties[each.key]
+}
+
+output "options" {
+  value = {
+    type = "object"
+    properties = {
+      for property, result in module.property : property => result.options
+    }
+  }
+
+  precondition {
+    condition = can(var.options.properties)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.property,
+      "properties",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = can(keys(local.properties))
+    error_message = format(
+      local.error_messages.wrong_properties_field_type,
+      var.property,
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = local.properties_size > 0
+    error_message = format(
+      local.error_messages.empty_properties,
+      var.property,
+      var.name,
+      var.path,
+    )
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/object/property/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/object/property/outputs.tf
@@ -1,0 +1,84 @@
+locals {
+  error_messages = {
+    field_not_found       = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The property "%s.%s" are required.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    invalid_property_type = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The type for the property "%s" must be one of %#v (got "%s").
+      (metadata.name: "%s"; path: "%s")
+    EOT
+  }
+
+  valid_types = ["string", "integer", "bool"]
+  type        = try(var.options.type, "empty")
+
+  common_options = {
+    description  = try(var.options.description, null)
+    externalDocs = try(var.options.externalDocs, null)
+  }
+  options = flatten([
+    module.string[*].options,
+    module.integer[*].options,
+    module.bool[*].options,
+  ])
+}
+
+module "string" {
+  source = "../../string/"
+  count  = local.type == "string" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+module "integer" {
+  source = "../../integer/"
+  count  = local.type == "integer" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+module "bool" {
+  source = "../../bool/"
+  count  = local.type == "bool" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+output "options" {
+  value = merge(local.common_options, local.options...)
+
+  precondition {
+    condition = can(var.options.type)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.property,
+      "type",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = try(contains(local.valid_types, var.options.type), true)
+    error_message = format(
+      local.error_messages.invalid_property_type,
+      var.property,
+      local.valid_types,
+      local.type,
+      var.name,
+      var.path,
+    )
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/object/property/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/object/property/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "property" {
+  type = string
+}
+
+variable "options" {
+  type = any
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/object/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/object/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "property" {
+  type = string
+}
+
+variable "options" {
+  type = any
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/outputs.tf
@@ -1,0 +1,106 @@
+locals {
+  error_messages = {
+    field_not_found       = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The property "%s.%s" are required.
+      (metadata.name: "%s"; path: "%s")
+    EOT
+    invalid_property_type = <<-EOT
+      Invalid "version" for CustomResourceDefinition!
+      The type for the property "%s" must be one of %#v (got "%s").
+      (metadata.name: "%s"; path: "%s")
+    EOT
+  }
+
+  valid_types = ["string", "integer", "array", "object", "bool"]
+  type        = try(var.options.type, "empty")
+
+  common_options = {
+    description  = try(var.options.description, null)
+    externalDocs = try(var.options.externalDocs, null)
+  }
+  options = flatten([
+    module.string[*].options,
+    module.integer[*].options,
+    module.bool[*].options,
+    module.object[*].options,
+    module.array[*].options,
+  ])
+}
+
+module "string" {
+  source = "./string/"
+  count  = local.type == "string" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+module "integer" {
+  source = "./integer/"
+  count  = local.type == "integer" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+module "bool" {
+  source = "./bool/"
+  count  = local.type == "bool" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+module "object" {
+  source = "./object/"
+  count  = local.type == "object" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+module "array" {
+  source = "./array/"
+  count  = local.type == "array" ? 1 : 0
+
+  path     = var.path
+  name     = var.name
+  property = var.property
+  options  = var.options
+}
+
+output "options" {
+  value = merge(local.common_options, local.options...)
+
+  precondition {
+    condition = can(var.options.type)
+    error_message = format(
+      local.error_messages.field_not_found,
+      var.property,
+      "type",
+      var.name,
+      var.path,
+    )
+  }
+
+  precondition {
+    condition = try(contains(local.valid_types, var.options.type), true)
+    error_message = format(
+      local.error_messages.invalid_property_type,
+      var.property,
+      local.valid_types,
+      local.type,
+      var.name,
+      var.path,
+    )
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/string/outputs.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/string/outputs.tf
@@ -1,0 +1,7 @@
+output "options" {
+  value = {
+    type      = "string"
+    minLength = try(tonumber(var.options.minLength), null)
+    maxLength = try(tonumber(var.options.maxLength), null)
+  }
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/string/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/string/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "property" {
+  type = string
+}
+
+variable "options" {
+  type = any
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/property/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/property/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "property" {
+  type = string
+}
+
+variable "options" {
+  type = any
+}

--- a/modules/CustomResourceDefinition/v1alpha2/version/variables.tf
+++ b/modules/CustomResourceDefinition/v1alpha2/version/variables.tf
@@ -1,0 +1,15 @@
+variable "path" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "index" {
+  type = number
+}
+
+variable "schema_version" {
+  type = any
+}

--- a/modules/resource/property/bool/outputs.tf
+++ b/modules/resource/property/bool/outputs.tf
@@ -2,7 +2,7 @@ locals {
   error_messages = {
     null_value    = <<-EOT
       Invalid resource manifest!
-      The property "%s" can not be null.
+      The property "%s" is null and no default value was defined.
       (metadata.name: "%s"; path: "%s")
     EOT
     invalid_value = <<-EOT
@@ -11,13 +11,18 @@ locals {
       (metadata.name: "%s"; path: "%s")
     EOT
   }
+
+  has_default_value    = try(var.schema.default, null) != null
+  default_value        = try(var.schema.default, null)
+  property_final_value = var.value != null ? var.value : local.has_default_value ? local.default_value : null
+
 }
 
 output "value" {
-  value = tobool(var.value)
+  value = tobool(local.property_final_value)
 
   precondition {
-    condition = var.value != null
+    condition = local.property_final_value != null
     error_message = format(
       local.error_messages.null_value,
       var.property,
@@ -27,7 +32,7 @@ output "value" {
   }
 
   precondition {
-    condition = can(tobool(var.value))
+    condition = can(tobool(local.property_final_value))
     error_message = format(
       local.error_messages.invalid_value,
       var.property,

--- a/resources.tf
+++ b/resources.tf
@@ -12,5 +12,6 @@ module "resources" {
   manifest = local.resource_manifests[count.index]
   custom_resource_definitions = flatten(concat(
     module.custom_resource_definitions_v1alpha1[*].schemas,
+    module.custom_resource_definitions_v1alpha2[*].schemas,
   ))
 }

--- a/tests/fixtures/user.gcp.iam.crd.yaml
+++ b/tests/fixtures/user.gcp.iam.crd.yaml
@@ -1,0 +1,31 @@
+apiVersion: tf-gapi.lukerops.com/v1alpha1
+kind: CustomResourceDefinition
+metadata:
+  name: user.gcp.iam
+spec:
+  group: gcp.iam
+  kind: User
+  versions:
+    - name: v1alpha1
+      specSchema:
+        type: object
+        properties:
+          name:
+            type: string
+          email:
+            type: string
+          active:
+            type: bool
+          points:
+            type: array
+            items:
+              type: integer
+          meta:
+            type: object
+            properties:
+              name:
+                type: string
+              number:
+                type: integer
+              boolean:
+                type: bool

--- a/tests/fixtures/user.gcp.iam.crd_v1alpha2.yaml
+++ b/tests/fixtures/user.gcp.iam.crd_v1alpha2.yaml
@@ -1,0 +1,50 @@
+apiVersion: tf-gapi.lukerops.com/v1alpha2
+kind: CustomResourceDefinition
+metadata:
+  name: user.gcp.iam
+spec:
+  group: gcp.iam
+  kind: User
+  versions:
+    - name: v1alpha2
+      specSchema:
+        type: object
+        properties:
+          name:
+            type: string
+          active:
+            type: bool
+            default: true
+
+    - name: v1alpha3
+      specSchema:
+        type: object
+        properties:
+          name:
+            type: string
+          active:
+            type: bool
+            default: false
+
+---
+apiVersion: gcp.iam/v1alpha2
+kind: User
+metadata:
+  name: user-teste-default-bool-true
+spec:
+  name: Usuário Teste default true
+---
+apiVersion: gcp.iam/v1alpha3
+kind: User
+metadata:
+  name: user-teste-default-bool-false
+spec:
+  name: Usuário Teste default false
+---
+apiVersion: gcp.iam/v1alpha2
+kind: User
+metadata:
+  name: user-teste-define-bool-value
+spec:
+  name: Usuário Teste define bool false
+  active: false

--- a/tests/fixtures/user.gcp.iam.manifest.yaml
+++ b/tests/fixtures/user.gcp.iam.manifest.yaml
@@ -1,0 +1,31 @@
+apiVersion: gcp.iam/v1alpha1
+kind: User
+metadata:
+  name: user-teste
+spec:
+  name: Usuário Teste
+  email: user-teste@server.com
+  active: true
+  points:
+    - 1
+    - 2
+  meta:
+    name: "Meta Name 1"
+    number: 42
+    boolean: false
+---
+apiVersion: gcp.iam/v1alpha1
+kind: User
+metadata:
+  name: user-teste-2
+spec:
+  name: Usuário Teste 2
+  email: user-teste-2@server.com
+  active: false
+  points:
+    - 3
+    - 4
+  meta:
+    name: "Meta Name 2"
+    number: 39
+    boolean: true

--- a/tests/test_output_by_apigroup.tftest.hcl
+++ b/tests/test_output_by_apigroup.tftest.hcl
@@ -1,0 +1,22 @@
+
+run "valida_output_por_apigroup" {
+  command = plan
+  variables {
+    yamls = [
+      "tests/fixtures/user.gcp.iam.crd.yaml",
+      "tests/fixtures/user.gcp.iam.manifest.yaml",
+    ]
+  }
+
+  assert {
+    condition     = contains(keys(module.groupResources.groupedResources), "gcp.iam")
+    error_message = "GroupResources não agrupou por apigroup gcp.iam"
+  }
+
+  assert {
+    condition     = length(keys(module.groupResources.groupedResources)) == 1
+    error_message = "Deveria haver apenas um apigroup: gcp.iam"
+  }
+
+}
+

--- a/tests/test_parse_manifest_with_v1alpha1_crd_full_fields.tftest.hcl
+++ b/tests/test_parse_manifest_with_v1alpha1_crd_full_fields.tftest.hcl
@@ -1,0 +1,68 @@
+run "parse_manifest_crd_v1alpha1_full_fields" {
+  command = plan
+
+  variables {
+    yamls = [
+      "tests/fixtures/user.gcp.iam.crd.yaml",
+      "tests/fixtures/user.gcp.iam.manifest.yaml",
+    ]
+  }
+
+  assert {
+    condition     = abspath(module.resources[0].instance.path) == abspath("${path.module}/tests/fixtures/user.gcp.iam.manifest.yaml")
+    error_message = "Não parseou manifesto correto"
+  }
+
+  assert {
+    condition     = module.resources[0].instance.metadata.name == "user-teste"
+    error_message = "Não paresou primeiro manifesto kind: User"
+  }
+
+  assert {
+    condition     = module.resources[1].instance.metadata.name == "user-teste-2"
+    error_message = "Não paresou primeiro manifesto kind: User"
+  }
+
+  assert {
+    condition = {
+      name   = module.resources[0].instance.spec.name,
+      email  = module.resources[0].instance.spec.email
+      active = module.resources[0].instance.spec.active
+      points = module.resources[0].instance.spec.points
+      meta   = module.resources[0].instance.spec.meta
+      } == {
+      email  = "user-teste@server.com"
+      name   = "Usuário Teste",
+      active = true
+      points = [1, 2]
+      meta = {
+        name    = "Meta Name 1"
+        number  = 42
+        boolean = false
+      }
+    }
+    error_message = "Não parseou campos do primeiro manifesto"
+  }
+
+  assert {
+    condition = {
+      name   = module.resources[1].instance.spec.name,
+      email  = module.resources[1].instance.spec.email
+      active = module.resources[1].instance.spec.active
+      points = module.resources[1].instance.spec.points
+      meta   = module.resources[1].instance.spec.meta
+      } == {
+      email  = "user-teste-2@server.com"
+      name   = "Usuário Teste 2",
+      active = false
+      points = [3, 4]
+      meta = {
+        name    = "Meta Name 2"
+        number  = 39
+        boolean = true
+      }
+    }
+    error_message = "Não parseou campos do primeiro manifesto"
+  }
+
+}

--- a/tests/test_parse_manifest_with_v1alpha2_crd_full_fields.tftest.hcl
+++ b/tests/test_parse_manifest_with_v1alpha2_crd_full_fields.tftest.hcl
@@ -1,0 +1,43 @@
+run "parse_manifest_crd_v1alpha2_default_value_boolean_field" {
+  command = plan
+
+  variables {
+    yamls = [
+      "tests/fixtures/user.gcp.iam.crd_v1alpha2.yaml",
+    ]
+  }
+
+  assert {
+    condition = {
+      name   = module.resources[0].instance.spec.name,
+      active = module.resources[0].instance.spec.active
+      } == {
+      name   = "Usuário Teste default true"
+      active = true
+    }
+    error_message = "Não considerou o valor default do campo boolean"
+  }
+
+  assert {
+    condition = {
+      name   = module.resources[1].instance.spec.name,
+      active = module.resources[1].instance.spec.active
+      } == {
+      name   = "Usuário Teste default false"
+      active = false
+    }
+    error_message = "Não considerou o valor default do campo boolean"
+  }
+
+  assert {
+    condition = {
+      name   = module.resources[2].instance.spec.name,
+      active = module.resources[2].instance.spec.active
+      } == {
+      name   = "Usuário Teste define bool false"
+      active = false
+    }
+    error_message = "Não considerou o valor default do campo boolean"
+  }
+
+}


### PR DESCRIPTION
Esse PR implementa a possibilidade de termos um valor defaut para campos boolean. Dessa forma, quando um CRD define um campo boolean, um manifesto validado por esse CRD não precisa declarar esse campo. Nesse caso o campo receberá o valor default que está definido no respectivo CRD.

Escolhi criar uma nova versão para os CRDs (`v1alpha2`) mas como o novo campo é opcional poderíamos alterar direto no v1alpha1 mesmo e quando uma pessoa atualizar o projeto, pegando uma versão mais nova do que a `v0.1.0` já teria a possibilidade de usar essa nova funcionalidade. Isso é possível pois o CRD v1alpha2 é retro-compatível com o v1alhpa1. Aqui será uma questão de escolha mesmo, quase estética. Acho que vale deixar duas versões até para que possamos ajustar o código do projeto para estar preparado para suportar múltiplas versões de CRDs de forma concorrente.


**Atenção**: Esse PR deveria ser aberto em relação ao #11, mas como a branch `feat/add-unittests` só existe no meu fork, não temos como abrir um PR em relação ao outro. Deixarei esse como draft até que o #11 seja mergeado, nesse momento esse PR aqui ficará corretamente atualizado.

Se preferir pode fazern o review do(s) commit(s) que adicionam a nova funcionalidade.